### PR TITLE
combined role for contact adviser journey

### DIFF
--- a/app/views/current/agreed/csi/_CSIBASE.html
+++ b/app/views/current/agreed/csi/_CSIBASE.html
@@ -56,9 +56,9 @@
                     <a href="{% if not (page == 'claim') %}claim{% if contactCentre %}-contact{% elif phase %}-{{phase}}{% endif %}{% else %}" class="active" aria-current="section{% endif %}">Case details</a>
                   </li>
 {% endif %}
-{% if payments or contactCentre %}
+{% if payments or contactCentre or (phase == "payment-adviser") %}
 <li>
-  <a href="{% if not (page == 'invoice') %}invoice{% if contactCentre %}-contact{% endif %}{% else %}" class="active" aria-current="section{% endif %}">Invoice details</a>
+  <a href="{% if not (page == 'invoice') %}invoice{%if phase == "payment-adviser" %}-payment-adviser{% endif %}{% if contactCentre %}-contact{% endif %}{% else %}" class="active" aria-current="section{% endif %}">Invoice details</a>
 </li>
 {% endif %}
 

--- a/app/views/current/agreed/csi/invoice-payment-adviser.html
+++ b/app/views/current/agreed/csi/invoice-payment-adviser.html
@@ -1,0 +1,2 @@
+{% set phase = "payment-adviser" %}
+{% extends "./invoice.html" %}

--- a/app/views/current/agreed/csi/invoice.html
+++ b/app/views/current/agreed/csi/invoice.html
@@ -1,7 +1,10 @@
 {% set page = "invoice" %}
 {% set claim = "true" %}
+
+{% if not phase %}
 {% set payments = 'true' %}
 {% set phase = "payment" %}
+{% endif %}
 {% set title = "Invoice details" %}
 
 {% if not contactCentre %}
@@ -12,10 +15,17 @@
 
 {% block csi %}
 
-<br>
-{% if not contactCentre %}
-<p class="govuk-body">You can change invoice details here after you have added it in the tasks.</p>
+{% if phase == "payment-adviser" %}
+{% set contactCentre = true %}
 {% endif %}
+
+<br>
+{% if not contactCentre and not payment %}
+<p class="govuk-body">You can change invoice details here after you have added it in the tasks.</p>
+{% else %}
+<P>[holder that only a payment officer can edit invoice details?]</p>
+{% endif %}
+
 
 {% macro defItem(key='', value='', money='', hideChange='') %}
   <div class="govuk-summary-list__row">

--- a/app/views/current/index.html
+++ b/app/views/current/index.html
@@ -182,6 +182,7 @@
                       <ul class="govuk-list">
                       <li><a class="govuk-link" href="/{{folder}}/agreed/your-cases-payment-adviser">Your cases</a></li>
                       <li><a class="govuk-link" href="/{{folder}}/agreed/csi/claim-payment-adviser">Case details</a></li>
+                      <li><a class="govuk-link" href="/{{folder}}/agreed/csi/invoice-payment-adviser">Invoice</a> (NEW) - read only </li>                      
                       <li><a class="govuk-link" href="/{{folder}}/agreed/csi/index-payment-adviser">Your tasks</a>
 
                       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
invoice tab appears (read only) when evidence is received - this also means that anyone with adviser privilege but who isn't allocated to the case (e.g. contact centre) can see details and change some things but not actually continue the case